### PR TITLE
feat(cli): add --list-ops flag to display available operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Usage of calcdate:
   -format string
         Output format: iso, sql, ts, human, compact, or Unix date format
         (e.g., '%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M:%S %Z')
+  -list-ops
+        List all available operations
   -list-tz
         List timezones
   -skip-weekends
@@ -88,6 +90,21 @@ Usage of calcdate:
 ```
 
 **The -expr (or -x) parameter is required, or provide the expression via stdin.**
+
+### Discovering Operations
+
+To see all available date operations with examples, use:
+
+```bash
+calcdate --list-ops
+```
+
+This displays a comprehensive list of all operations organized by category:
+- **Date Values**: `today`, `now`, `yesterday`, `tomorrow`, weekday names
+- **Arithmetic Operations**: `+` and `-` with time units (s, m, h, d, w, M, Y, q)
+- **Boundary Operations**: `startOfMonth`, `endOfMonth`, `startOfWeek`, etc.
+- **Value Setters**: `day`, `time`
+- **Transform Operations**: `round`, `trunc`
 
 ## Examples
 

--- a/cmd/calcdate/main.go
+++ b/cmd/calcdate/main.go
@@ -24,6 +24,47 @@ func printVersion() {
 	fmt.Println(version)
 }
 
+// printOperationsList prints a comprehensive list of all available operations.
+func printOperationsList() {
+	registry := calcdate.GetOperationRegistry()
+
+	fmt.Println("Available Operations:")
+	fmt.Println()
+
+	for _, category := range registry {
+		// Print category header
+		fmt.Printf("%s:\n", strings.ToUpper(category.Name))
+
+		// Print each operation in the category
+		for _, op := range category.Operations {
+			fmt.Printf("  %-20s %s\n", op.Name, op.Description)
+			fmt.Printf("  %-20s Example: %s\n", "", op.Example)
+
+			// Print aliases if any
+			if len(op.Aliases) > 0 {
+				fmt.Printf("  %-20s Aliases: %s\n", "", strings.Join(op.Aliases, ", "))
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Println("For more information, see the README or visit:")
+	fmt.Println("https://github.com/sgaunet/calcdate")
+}
+
+// printCustomUsage prints enhanced usage information with quick examples.
+func printCustomUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: calcdate [options]\n\n")
+	fmt.Fprintf(os.Stderr, "Options:\n")
+	flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nQuick Examples:\n")
+	fmt.Fprintf(os.Stderr, "  calcdate -x \"today +1d\"                    # Tomorrow\n")
+	fmt.Fprintf(os.Stderr, "  calcdate -x \"now | +2h | round hour\"       # 2 hours from now, rounded\n")
+	fmt.Fprintf(os.Stderr, "  calcdate -x \"today | startofmonth\"         # First day of month\n")
+	fmt.Fprintf(os.Stderr, "  calcdate -x \"today...+7d\" -each 1d         # Next 7 days\n")
+	fmt.Fprintf(os.Stderr, "\nUse --list-ops to see all available operations\n")
+}
+
 // isStdinRedirected checks if stdin is redirected (piped or from file).
 // Returns true if stdin is redirected, false if it's a terminal.
 func isStdinRedirected() bool {
@@ -60,6 +101,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if config.listOps {
+		printOperationsList()
+		os.Exit(0)
+	}
+
 	if config.vOption {
 		printVersion()
 		os.Exit(0)
@@ -89,15 +135,19 @@ func main() {
 type cliConfig struct {
 	tz                                            string
 	expr, each, transform, format                 string
-	vOption, listTZ, skipWeekends                 bool
+	vOption, listTZ, listOps, skipWeekends        bool
 }
 
 func parseCommandLineFlags() cliConfig {
 	var config cliConfig
 
+	// Set custom usage function
+	flag.Usage = printCustomUsage
+
 	// Legacy flags (kept)
 	flag.StringVar(&config.tz, "tz", "Local", "Input timezone")
 	flag.BoolVar(&config.listTZ, "list-tz", false, "List timezones")
+	flag.BoolVar(&config.listOps, "list-ops", false, "List all available operations")
 	flag.BoolVar(&config.vOption, "v", false, "Get version")
 
 	// New expression flags

--- a/e2etests/testsuite.yml
+++ b/e2etests/testsuite.yml
@@ -9,13 +9,31 @@ testcases:
     assertions:
     - result.code ShouldEqual 0
 
+# Tests for utility flags
+- name: list operations flag
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run ./cmd/calcdate --list-ops
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "Available Operations:"
+    - result.systemout ShouldContainSubstring "DATE VALUES:"
+    - result.systemout ShouldContainSubstring "today"
+    - result.systemout ShouldContainSubstring "ARITHMETIC OPERATIONS:"
+    - result.systemout ShouldContainSubstring "BOUNDARIES"
+    - result.systemout ShouldContainSubstring "startofmonth"
+    - result.systemout ShouldContainSubstring "endofmonth"
+    - result.systemout ShouldContainSubstring "Example:"
+
 # Tests for stdin functionality
 - name: stdin - basic expression
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(echo "today" | go run . --format sql)
+      result=$(echo "today" | go run ./cmd/calcdate --format sql)
       expected=$(date "+%Y-%m-%d 00:00:00")
       [ "$result" = "$expected" ]
     assertions:
@@ -26,8 +44,8 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      echo "today +1d" | go run . --format sql > /tmp/1
-      go run . -x "today +1d" --format sql > /tmp/2
+      echo "today +1d" | go run ./cmd/calcdate --format sql > /tmp/1
+      go run ./cmd/calcdate -x "today +1d" --format sql > /tmp/2
       diff -q /tmp/1 /tmp/2
     assertions:
     - result.code ShouldEqual 0
@@ -37,7 +55,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(echo "now" | go run . --format iso)
+      result=$(echo "now" | go run ./cmd/calcdate --format iso)
       # Check it matches ISO format pattern
       echo "$result" | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.*$"
     assertions:
@@ -48,8 +66,8 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      echo "today...+2d" | go run . --each 1d --format sql | head -n 2 > /tmp/1
-      go run . -x "today...+2d" --each 1d --format sql | head -n 2 > /tmp/2
+      echo "today...+2d" | go run ./cmd/calcdate --each 1d --format sql | head -n 2 > /tmp/1
+      go run ./cmd/calcdate -x "today...+2d" --each 1d --format sql | head -n 2 > /tmp/2
       diff -q /tmp/1 /tmp/2
     assertions:
     - result.code ShouldEqual 0
@@ -59,7 +77,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      echo "" | go run . 2>&1 | grep -q "no expression provided via stdin"
+      echo "" | go run ./cmd/calcdate 2>&1 | grep -q "no expression provided via stdin"
     assertions:
     - result.code ShouldEqual 0
 
@@ -69,7 +87,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x 'today' --format sql)
+      result=$(go run ./cmd/calcdate -x 'today' --format sql)
       expected=$(date "+%Y-%m-%d 00:00:00")
       [ "$result" = "$expected" ]
     assertions:
@@ -80,7 +98,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x 'now' --format sql)
+      result=$(go run ./cmd/calcdate -x 'now' --format sql)
       # Check it matches today's date pattern
       echo "$result" | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$"
     assertions:
@@ -91,7 +109,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x 'yesterday' --format sql > /tmp/1
+      go run ./cmd/calcdate -x 'yesterday' --format sql > /tmp/1
       if [[ "$OSTYPE" == "darwin"* ]]; then
         date -v-1d "+%Y-%m-%d 00:00:00" > /tmp/2
       else
@@ -106,7 +124,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x 'tomorrow' --format sql > /tmp/1
+      go run ./cmd/calcdate -x 'tomorrow' --format sql > /tmp/1
       if [[ "$OSTYPE" == "darwin"* ]]; then
         date -v+1d "+%Y-%m-%d 00:00:00" > /tmp/2
       else
@@ -121,20 +139,20 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15' --format sql
+      go run ./cmd/calcdate -x '2024-03-15' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-15 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-15 00:00:00"
 
 - name: expr - iso datetime
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15T14:30:45' --format sql
+      go run ./cmd/calcdate -x '2024-03-15T14:30:45' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-15 14:30:45"
+    - result.systemout ShouldContainSubstring "2024-03-15 14:30:45"
 
 # Tests for arithmetic operations
 - name: expr - add days
@@ -142,60 +160,60 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-15 +7d' --format sql
+      go run ./cmd/calcdate -x '2024-01-15 +7d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-22 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-22 00:00:00"
 
 - name: expr - subtract days
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-15 -3d' --format sql
+      go run ./cmd/calcdate -x '2024-01-15 -3d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-12 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-12 00:00:00"
 
 - name: expr - add weeks
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 +2w' --format sql
+      go run ./cmd/calcdate -x '2024-01-01 +2w' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-15 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-15 00:00:00"
 
 - name: expr - add months
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-31 +1M' --format sql
+      go run ./cmd/calcdate -x '2024-01-31 +1M' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-02 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-02 00:00:00"
 
 - name: expr - add years
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-02-29 +1Y' --format sql
+      go run ./cmd/calcdate -x '2024-02-29 +1Y' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-03-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2025-03-01 00:00:00"
 
 - name: expr - multiple operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 +1M +2d +3h' --format sql
+      go run ./cmd/calcdate -x '2024-01-01 +1M +2d +3h' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-03 03:00:00"
+    - result.systemout ShouldContainSubstring "2024-02-03 03:00:00"
 
 # Tests for pipeline operations
 - name: expr - pipe operations
@@ -203,190 +221,190 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-15 | +1M | +2d' --format sql
+      go run ./cmd/calcdate -x '2024-01-15 | +1M | +2d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-17 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-02-17 00:00:00"
 
 - name: expr - startOfMonth
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15 | startOfMonth' --format sql
+      go run ./cmd/calcdate -x '2024-03-15 | startOfMonth' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-01 00:00:00"
 
 - name: expr - endOfMonth
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-02-15 | endOfMonth' --format sql
+      go run ./cmd/calcdate -x '2024-02-15 | endOfMonth' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-29 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-02-29 23:59:59"
 
 - name: expr - startOfWeek
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15 | startOfWeek' --format sql
+      go run ./cmd/calcdate -x '2024-03-15 | startOfWeek' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-11 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-11 00:00:00"
 
 - name: expr - endOfWeek
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15 | endOfWeek' --format sql
+      go run ./cmd/calcdate -x '2024-03-15 | endOfWeek' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-17 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-03-17 23:59:59"
 
 - name: expr - startOfYear
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-07-15 | startOfYear' --format sql
+      go run ./cmd/calcdate -x '2024-07-15 | startOfYear' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00"
 
 - name: expr - endOfYear
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-07-15 | endOfYear' --format sql
+      go run ./cmd/calcdate -x '2024-07-15 | endOfYear' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-31 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-12-31 23:59:59"
 
 - name: expr - startOfHour
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | startOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | startOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:00:00"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:00:00"
 
 - name: expr - endOfHour
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | endOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | endOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:59:59"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:59:59"
 
 - name: expr - startOfMinute
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | startOfMinute' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | startOfMinute' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:34:00"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:34:00"
 
 - name: expr - endOfMinute
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | endOfMinute' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | endOfMinute' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:34:59"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:34:59"
 
 - name: expr - startOfSecond
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | startOfSecond' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | startOfSecond' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:34:45"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:34:45"
 
 - name: expr - endOfSecond
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | endOfSecond' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | endOfSecond' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:34:45"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:34:45"
 
 - name: expr - chained time boundary operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 | startOfHour | endOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 | startOfHour | endOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 12:59:59"
+    - result.systemout ShouldContainSubstring "2024-08-30 12:59:59"
 
 - name: expr - time boundaries with arithmetic
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 12:34:45 +1d | endOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 12:34:45 +1d | endOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-31 12:59:59"
+    - result.systemout ShouldContainSubstring "2024-08-31 12:59:59"
 
 - name: expr - time boundary edge cases
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-31 23:59:59 | startOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-12-31 23:59:59 | startOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-31 23:00:00"
+    - result.systemout ShouldContainSubstring "2024-12-31 23:00:00"
 
 - name: expr - midnight time boundaries
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-08-30 00:00:00 | endOfHour' --format sql
+      go run ./cmd/calcdate -x '2024-08-30 00:00:00 | endOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-08-30 00:59:59"
+    - result.systemout ShouldContainSubstring "2024-08-30 00:59:59"
 
 - name: expr - mixed pipeline operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-03-15 | startOfMonth | +1M | endOfMonth' --format sql
+      go run ./cmd/calcdate -x '2024-03-15 | startOfMonth | +1M | endOfMonth' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-04-30 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-04-30 23:59:59"
 
 - name: expr - operations without pipes
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-15 | endOfMonth +1d +1s' --format sql
+      go run ./cmd/calcdate -x '2024-01-15 | endOfMonth +1d +1s' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-02 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-02-02 00:00:00"
 
 # Tests for range expressions
 - name: expr - simple range
@@ -394,47 +412,47 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-01-05' --format sql
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-05' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00 - 2024-01-05 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00 - 2024-01-05 00:00:00"
 
 - name: expr - range with operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-01-01 | +7d' --format sql
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-01 | +7d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00 - 2024-01-08 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00 - 2024-01-08 00:00:00"
 
 - name: expr - range with endOfMonth
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-02-01 ... 2024-02-01 | endOfMonth' --format sql
+      go run ./cmd/calcdate -x '2024-02-01 ... 2024-02-01 | endOfMonth' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-01 00:00:00 - 2024-02-29 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-02-01 00:00:00 - 2024-02-29 23:59:59"
 
 - name: expr - range with multiple operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-01-01 | endOfMonth +1d +1s' --format sql
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-01 | endOfMonth +1d +1s' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00 - 2024-02-02 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00 - 2024-02-02 00:00:00"
 
 - name: expr - relative range
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x 'today ... today | +7d' --format sql | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}"
+      go run ./cmd/calcdate -x 'today ... today | +7d' --format sql | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}"
     assertions:
     - result.code ShouldEqual 0
 
@@ -444,7 +462,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01 ... 2024-01-04' --each 1d --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-04' --each 1d --format sql | wc -l | tr -d ' ')
       [ "$result" = "3" ]
     assertions:
     - result.code ShouldEqual 0
@@ -454,7 +472,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01 ... 2024-01-15' --each 1w --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-15' --each 1w --format sql | wc -l | tr -d ' ')
       [ "$result" = "2" ]
     assertions:
     - result.code ShouldEqual 0
@@ -464,7 +482,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01 ... 2024-04-01' --each 1M --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01 ... 2024-04-01' --each 1M --format sql | wc -l | tr -d ' ')
       [ "$result" = "3" ]
     assertions:
     - result.code ShouldEqual 0
@@ -474,17 +492,17 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-07-01' --each 1q --format sql | head -1
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-07-01' --each 1q --format sql | head -1
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00 - 2024-04-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00 - 2024-04-01 00:00:00"
 
 - name: expr - each hour iteration
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01T00:00:00 ... 2024-01-01T03:00:00' --each 1h --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01T00:00:00 ... 2024-01-01T03:00:00' --each 1h --format sql | wc -l | tr -d ' ')
       [ "$result" = "3" ]
     assertions:
     - result.code ShouldEqual 0
@@ -494,7 +512,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01 ... 2024-01-01 | +3d' --each 1d --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-01 | +3d' --each 1d --format sql | wc -l | tr -d ' ')
       [ "$result" = "3" ]
     assertions:
     - result.code ShouldEqual 0
@@ -505,20 +523,20 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-01-02' --each 1d --transform '$begin +8h, $end +20h' --format sql | head -1
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-02' --each 1d --transform '$begin +8h, $end +20h' --format sql | head -1
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 08:00:00 - 2024-01-02 20:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 08:00:00 - 2024-01-02 20:00:00"
 
 - name: expr - transform with operations
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 ... 2024-01-03' --each 1d --transform '$begin | startOfDay +9h, $end | startOfDay +17h' --format sql | head -1
+      go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-03' --each 1d --transform '$begin | startOfDay +9h, $end | startOfDay +17h' --format sql | head -1
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 09:00:00 - 2024-01-02 17:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 09:00:00 - 2024-01-02 17:00:00"
 
 # Tests for skip weekends
 - name: expr - skip weekends
@@ -527,7 +545,7 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Jan 6-7, 2024 is Saturday-Sunday
-      result=$(go run . -x '2024-01-05 ... 2024-01-09' --each 1d --skip-weekends --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-05 ... 2024-01-09' --each 1d --skip-weekends --format sql | wc -l | tr -d ' ')
       [ "$result" = "2" ]  # Only Friday and Monday
     assertions:
     - result.code ShouldEqual 0
@@ -537,7 +555,7 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      output=$(go run . -x '2024-01-05 ... 2024-01-09' --each 1d --skip-weekends --format sql)
+      output=$(go run ./cmd/calcdate -x '2024-01-05 ... 2024-01-09' --each 1d --skip-weekends --format sql)
       echo "$output" | grep -q "2024-01-05"  # Should contain Friday
       echo "$output" | grep -q "2024-01-08"  # Should contain Monday
       ! echo "$output" | grep -q "2024-01-06"  # Should NOT contain Saturday
@@ -551,40 +569,40 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01T10:00:00 +2h +30m +45s' --format sql
+      go run ./cmd/calcdate -x '2024-01-01T10:00:00 +2h +30m +45s' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 12:30:45"
+    - result.systemout ShouldContainSubstring "2024-01-01 12:30:45"
 
 - name: expr - round hour
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01T10:35:00 | round hour' --format sql
+      go run ./cmd/calcdate -x '2024-01-01T10:35:00 | round hour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 11:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 11:00:00"
 
 - name: expr - trunc hour
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01T10:35:00 | trunc hour' --format sql
+      go run ./cmd/calcdate -x '2024-01-01T10:35:00 | trunc hour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 10:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 10:00:00"
 
 - name: expr - set time
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-15 | time 14:30:00' --format sql
+      go run ./cmd/calcdate -x '2024-01-15 | time 14:30:00' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-15 14:30:00"
+    - result.systemout ShouldContainSubstring "2024-01-15 14:30:00"
 
 # Tests for timezone support
 - name: expr - timezone UTC
@@ -592,70 +610,70 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01T12:00:00' -tz UTC --format iso
+      go run ./cmd/calcdate -x '2024-01-01T12:00:00' -tz UTC --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01T12:00:00Z"
+    - result.systemout ShouldContainSubstring "2024-01-01T12:00:00Z"
 
 - name: expr - timezone conversion
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01T00:00:00' -tz 'America/New_York' --format iso
+      go run ./cmd/calcdate -x '2024-01-01T00:00:00' -tz 'America/New_York' --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01T00:00:00-05:00"
+    - result.systemout ShouldContainSubstring "2024-01-01T00:00:00-05:00"
 
 - name: expr - inline timezone UTC
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 UTC +1d | endOfMinute' --format sql
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 UTC +1d | endOfMinute' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-31 14:34:59"
+    - result.systemout ShouldContainSubstring "2025-08-31 14:34:59"
 
 - name: expr - inline timezone GMT
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 GMT | startOfHour' --format sql
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 GMT | startOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-30 14:00:00"
+    - result.systemout ShouldContainSubstring "2025-08-30 14:00:00"
 
 - name: expr - inline timezone EST
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 EST | endOfHour' --format sql
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 EST | endOfHour' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-30 19:59:59"
+    - result.systemout ShouldContainSubstring "2025-08-30 19:59:59"
 
 - name: expr - inline timezone CET
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 CET +2h' --format sql
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 CET +2h' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-30 14:34:45"
+    - result.systemout ShouldContainSubstring "2025-08-30 14:34:45"
 
 - name: expr - timezone with time boundaries
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 UTC | endOfHour +1d' --format sql
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 UTC | endOfHour +1d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-31 14:59:59"
+    - result.systemout ShouldContainSubstring "2025-08-31 14:59:59"
 
 # Tests for timezone precedence and behavior
 - name: expr - inline timezone parsing vs output flag
@@ -663,10 +681,10 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2025-08-30 12:34:45 EST' -tz UTC --format iso
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 EST' -tz UTC --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-30T17:34:45Z"
+    - result.systemout ShouldContainSubstring "2025-08-30T17:34:45Z"
 
 - name: expr - timezone precedence documentation
   steps:
@@ -674,7 +692,7 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Parse as UTC (inline), output in America/New_York (-tz flag)
-      result1=$(go run . -x '2025-08-30 12:00:00 UTC' -tz 'America/New_York' --format iso)
+      result1=$(go run ./cmd/calcdate -x '2025-08-30 12:00:00 UTC' -tz 'America/New_York' --format iso)
       echo "Input UTC, Output NYC: $result1"
       # Should show UTC time converted to NYC time (UTC-4 in summer)
       [[ "$result1" == *"08:00:00"* ]]
@@ -688,7 +706,7 @@ testcases:
       cd {{.venom.testsuite.workdir}}/..
       # Test that inline timezone + -tz flag work together logically
       # Parse 12:00 EST (17:00 UTC), output in UTC
-      go run . -x '2025-08-30 12:00:00 EST +3h' -tz UTC --format iso | grep "2025-08-30T20:00:00Z"
+      go run ./cmd/calcdate -x '2025-08-30 12:00:00 EST +3h' -tz UTC --format iso | grep "2025-08-30T20:00:00Z"
     assertions:
     - result.code ShouldEqual 0
 
@@ -699,10 +717,10 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Test the exact bug case: CET (UTC+2 in summer) with endOfMinute
-      go run . -x '2025-08-30 12:34:45 CET +1d | endOfMinute' -tz 'UTC' --format iso
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 CET +1d | endOfMinute' -tz 'UTC' --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-31T10:34:59Z"
+    - result.systemout ShouldContainSubstring "2025-08-31T10:34:59Z"
 
 - name: expr - timezone pipeline bug regression EST
   steps:
@@ -710,10 +728,10 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Test EST (UTC-5) with time boundary operations
-      go run . -x '2025-08-30 12:34:45 EST | endOfHour +1d' -tz 'UTC' --format iso
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 EST | endOfHour +1d' -tz 'UTC' --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-31T17:59:59Z"
+    - result.systemout ShouldContainSubstring "2025-08-31T17:59:59Z"
 
 - name: expr - timezone boundary operations chaining
   steps:
@@ -721,10 +739,10 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Test multiple chained boundary operations with timezone conversion
-      go run . -x '2025-08-30 12:34:45 EST | startOfHour | endOfHour' -tz 'UTC' --format iso
+      go run ./cmd/calcdate -x '2025-08-30 12:34:45 EST | startOfHour | endOfHour' -tz 'UTC' --format iso
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2025-08-30T17:59:59Z"
+    - result.systemout ShouldContainSubstring "2025-08-30T17:59:59Z"
 
 - name: expr - timezone all boundary operations
   steps:
@@ -732,9 +750,9 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Test that all time boundary operations preserve timezone context
-      result1=$(go run . -x '2025-08-30 12:34:45 UTC | startOfMinute' -tz 'EST' --format iso)
-      result2=$(go run . -x '2025-08-30 12:34:45 UTC | startOfSecond' -tz 'EST' --format iso)  
-      result3=$(go run . -x '2025-08-30 12:34:45 UTC | startOfDay' -tz 'EST' --format iso)
+      result1=$(go run ./cmd/calcdate -x '2025-08-30 12:34:45 UTC | startOfMinute' -tz 'EST' --format iso)
+      result2=$(go run ./cmd/calcdate -x '2025-08-30 12:34:45 UTC | startOfSecond' -tz 'EST' --format iso)  
+      result3=$(go run ./cmd/calcdate -x '2025-08-30 12:34:45 UTC | startOfDay' -tz 'EST' --format iso)
       # All should show correct UTC->EST conversions (UTC-5)
       [[ "$result1" == *"07:34:00"* ]] && [[ "$result2" == *"07:34:45"* ]] && [[ "$result3" == *"19:00:00"* ]]
     assertions:
@@ -747,50 +765,50 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '%Y-%m-%d'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '%Y-%m-%d'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25"
+    - result.systemout ShouldContainSubstring "2024-12-25"
 
 - name: format - Unix basic date and time
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '%Y-%m-%d %H:%M:%S'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '%Y-%m-%d %H:%M:%S'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 14:30:45"
+    - result.systemout ShouldContainSubstring "2024-12-25 14:30:45"
 
 - name: format - Unix 2-digit year
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format '%y/%m/%d'
+      go run ./cmd/calcdate -x '2024-12-25' --format '%y/%m/%d'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "24/12/25"
+    - result.systemout ShouldContainSubstring "24/12/25"
 
 - name: format - Unix 12-hour format with AM/PM
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '%Y-%m-%d %I:%M:%S %p'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '%Y-%m-%d %I:%M:%S %p'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 02:30:45 PM"
+    - result.systemout ShouldContainSubstring "2024-12-25 02:30:45 PM"
 
 - name: format - Unix 12-hour format AM
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 09:15:30' --format '%I:%M %p'
+      go run ./cmd/calcdate -x '2024-12-25 09:15:30' --format '%I:%M %p'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "09:15 AM"
+    - result.systemout ShouldContainSubstring "09:15 AM"
 
 # Unix weekday and month name formats
 - name: format - Unix short weekday and month
@@ -798,20 +816,20 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format '%a, %b %d'
+      go run ./cmd/calcdate -x '2024-12-25' --format '%a, %b %d'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Wed, Dec 25"
+    - result.systemout ShouldContainSubstring "Wed, Dec 25"
 
 - name: format - Unix full weekday and month
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format '%A, %B %d, %Y'
+      go run ./cmd/calcdate -x '2024-12-25' --format '%A, %B %d, %Y'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Wednesday, December 25, 2024"
+    - result.systemout ShouldContainSubstring "Wednesday, December 25, 2024"
 
 # Unix timezone formats  
 - name: format - Unix timezone name
@@ -819,30 +837,30 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 12:00:00' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
+      go run ./cmd/calcdate -x '2024-12-25 12:00:00' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 12:00:00 UTC"
+    - result.systemout ShouldContainSubstring "2024-12-25 12:00:00 UTC"
 
 - name: format - Unix timezone offset
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 12:00:00' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %z'
+      go run ./cmd/calcdate -x '2024-12-25 12:00:00' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 12:00:00 +0000"
+    - result.systemout ShouldContainSubstring "2024-12-25 12:00:00 +0000"
 
 - name: format - Unix timezone EST conversion
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 17:00:00 UTC' -tz 'EST' --format '%Y-%m-%d %H:%M:%S %Z'
+      go run ./cmd/calcdate -x '2024-12-25 17:00:00 UTC' -tz 'EST' --format '%Y-%m-%d %H:%M:%S %Z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 12:00:00 EST"
+    - result.systemout ShouldContainSubstring "2024-12-25 12:00:00 EST"
 
 # Unix additional formats
 - name: format - Unix day of year
@@ -850,10 +868,10 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format 'Day %j of %Y'
+      go run ./cmd/calcdate -x '2024-12-25' --format 'Day %j of %Y'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Day 360 of 2024"
+    - result.systemout ShouldContainSubstring "Day 360 of 2024"
 
 - name: format - Unix weekday numbers
   steps:
@@ -861,20 +879,20 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Note: %w and %u don't have direct Go equivalents, so we test basic functionality  
-      go run . -x '2024-12-25' --format 'Day %j of year %Y'
+      go run ./cmd/calcdate -x '2024-12-25' --format 'Day %j of year %Y'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Day 360 of year 2024"
+    - result.systemout ShouldContainSubstring "Day 360 of year 2024"
 
 - name: format - Unix literal percent
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format 'Test %% literal on %Y-%m-%d'  
+      go run ./cmd/calcdate -x '2024-12-25' --format 'Test %% literal on %Y-%m-%d'  
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Test % literal on 2024-12-25"
+    - result.systemout ShouldContainSubstring "Test % literal on 2024-12-25"
 
 # Complex Unix format combinations
 - name: format - Unix complex mixed format
@@ -882,10 +900,10 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' -tz 'UTC' --format '%A, %B %d, %Y at %I:%M %p %Z'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' -tz 'UTC' --format '%A, %B %d, %Y at %I:%M %p %Z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Wednesday, December 25, 2024 at 02:30 PM UTC"
+    - result.systemout ShouldContainSubstring "Wednesday, December 25, 2024 at 02:30 PM UTC"
 
 # Backward compatibility with Go formats
 - name: format - Go format basic date
@@ -893,50 +911,50 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '2006-01-02'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '2006-01-02'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25"
+    - result.systemout ShouldContainSubstring "2024-12-25"
 
 - name: format - Go format with time
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '2006/01/02 15:04:05'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '2006/01/02 15:04:05'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024/12/25 14:30:45"
+    - result.systemout ShouldContainSubstring "2024/12/25 14:30:45"
 
 - name: format - Go format custom layout
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format 'Monday, January 2, 2006'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format 'Monday, January 2, 2006'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Wednesday, December 25, 2024"
+    - result.systemout ShouldContainSubstring "Wednesday, December 25, 2024"
 
 - name: format - Go format time only
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format '15:04:05'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format '15:04:05'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "14:30:45"
+    - result.systemout ShouldContainSubstring "14:30:45"
 
 - name: format - Go format with timezone
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' -tz 'UTC' --format '2006-01-02T15:04:05Z07:00'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' -tz 'UTC' --format '2006-01-02T15:04:05Z07:00'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25T14:30:45Z"
+    - result.systemout ShouldContainSubstring "2024-12-25T14:30:45Z"
 
 # Format with timezone inline vs flag
 - name: format - Unix format inline timezone vs flag
@@ -944,20 +962,20 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 12:00:00 EST' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
+      go run ./cmd/calcdate -x '2024-12-25 12:00:00 EST' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 17:00:00 UTC"
+    - result.systemout ShouldContainSubstring "2024-12-25 17:00:00 UTC"
 
 - name: format - Unix format preserve inline timezone
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 12:00:00 EST | startOfHour' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
+      go run ./cmd/calcdate -x '2024-12-25 12:00:00 EST | startOfHour' -tz 'UTC' --format '%Y-%m-%d %H:%M:%S %Z'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 17:00:00 UTC"
+    - result.systemout ShouldContainSubstring "2024-12-25 17:00:00 UTC"
 
 # Format short flags
 - name: format - Unix format with short flag
@@ -965,10 +983,10 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' -f '%b %d, %Y'
+      go run ./cmd/calcdate -x '2024-12-25' -f '%b %d, %Y'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Dec 25, 2024"
+    - result.systemout ShouldContainSubstring "Dec 25, 2024"
 
 # Format edge cases
 - name: format - empty format uses default SQL
@@ -976,60 +994,60 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format ''
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format ''
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 14:30:45"
+    - result.systemout ShouldContainSubstring "2024-12-25 14:30:45"
 
 - name: format - predefined iso format
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' -tz 'UTC' --format 'iso'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' -tz 'UTC' --format 'iso'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25T14:30:45Z"
+    - result.systemout ShouldContainSubstring "2024-12-25T14:30:45Z"
 
 - name: format - predefined sql format
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45' --format 'sql'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45' --format 'sql'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-12-25 14:30:45"
+    - result.systemout ShouldContainSubstring "2024-12-25 14:30:45"
 
 - name: format - predefined human format
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format 'human'
+      go run ./cmd/calcdate -x '2024-12-25' --format 'human'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Wednesday, December 25, 2024"
+    - result.systemout ShouldContainSubstring "Wednesday, December 25, 2024"
 
 - name: format - predefined compact format
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25' --format 'compact'
+      go run ./cmd/calcdate -x '2024-12-25' --format 'compact'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "20241225"
+    - result.systemout ShouldContainSubstring "20241225"
 
 - name: format - predefined timestamp format
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 00:00:00' -tz 'UTC' --format 'ts'
+      go run ./cmd/calcdate -x '2024-01-01 00:00:00' -tz 'UTC' --format 'ts'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "1704067200"
+    - result.systemout ShouldContainSubstring "1704067200"
 
 # Format with operations
 - name: format - Unix format with operations
@@ -1037,10 +1055,10 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-12-25 14:30:45 | +1d | endOfDay' --format '%A, %B %d at %H:%M:%S'
+      go run ./cmd/calcdate -x '2024-12-25 14:30:45 | +1d | endOfDay' --format '%A, %B %d at %H:%M:%S'
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "Thursday, December 26 at 23:59:59"
+    - result.systemout ShouldContainSubstring "Thursday, December 26 at 23:59:59"
 
 # Edge cases and error conditions
 - name: expr - leap year handling
@@ -1048,67 +1066,67 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-02-29' --format sql
+      go run ./cmd/calcdate -x '2024-02-29' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-02-29 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-02-29 00:00:00"
 
 - name: expr - non leap year
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2023-02-28 +1d' --format sql
+      go run ./cmd/calcdate -x '2023-02-28 +1d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2023-03-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2023-03-01 00:00:00"
 
 - name: expr - month boundary
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-31 +1M' --format sql
+      go run ./cmd/calcdate -x '2024-01-31 +1M' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-02 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-02 00:00:00"
 
 - name: expr - year boundary
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2023-12-31 +1d' --format sql
+      go run ./cmd/calcdate -x '2023-12-31 +1d' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00"
 
 - name: expr - startOfQuarter
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-05-15 | startOfQuarter' --format sql
+      go run ./cmd/calcdate -x '2024-05-15 | startOfQuarter' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-04-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-04-01 00:00:00"
 
 - name: expr - endOfQuarter
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-05-15 | endOfQuarter' --format sql
+      go run ./cmd/calcdate -x '2024-05-15 | endOfQuarter' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-06-30 23:59:59"
+    - result.systemout ShouldContainSubstring "2024-06-30 23:59:59"
 
 - name: expr - complex pipeline
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x 'today | startOfMonth | -1d | endOfMonth' --format sql | grep -E "[0-9]{4}-[0-9]{2}-[0-9]{2} 23:59:59"
+      go run ./cmd/calcdate -x 'today | startOfMonth | -1d | endOfMonth' --format sql | grep -E "[0-9]{4}-[0-9]{2}-[0-9]{2} 23:59:59"
     assertions:
     - result.code ShouldEqual 0
 
@@ -1118,7 +1136,7 @@ testcases:
     script: |
       cd {{.venom.testsuite.workdir}}/..
       # Find next Monday from 2024-01-01 (which is a Monday)
-      go run . -x 'monday' --format sql | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$"
+      go run ./cmd/calcdate -x 'monday' --format sql | grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$"
     assertions:
     - result.code ShouldEqual 0
 
@@ -1127,17 +1145,17 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-06-15 -3M' --format sql
+      go run ./cmd/calcdate -x '2024-06-15 -3M' --format sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-03-15 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-03-15 00:00:00"
 
 - name: expr - multiple format outputs
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      ts=$(go run . -x '2024-01-01T00:00:00' -tz UTC --format ts)
+      ts=$(go run ./cmd/calcdate -x '2024-01-01T00:00:00' -tz UTC --format ts)
       [ "$ts" = "1704067200" ]
     assertions:
     - result.code ShouldEqual 0
@@ -1147,17 +1165,17 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01' -f sql
+      go run ./cmd/calcdate -x '2024-01-01' -f sql
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "2024-01-01 00:00:00"
+    - result.systemout ShouldContainSubstring "2024-01-01 00:00:00"
 
 - name: expr - range with same start and end
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x 'today ... today' --format sql | grep -E "00:00:00 - [0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00"
+      go run ./cmd/calcdate -x 'today ... today' --format sql | grep -E "00:00:00 - [0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00"
     assertions:
     - result.code ShouldEqual 0
 
@@ -1166,27 +1184,27 @@ testcases:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-01-01 |' --format sql 2>&1 | grep -q -i "error\|failed" && echo "FAILED" || echo "PASSED"
+      go run ./cmd/calcdate -x '2024-01-01 |' --format sql 2>&1 | grep -q -i "error\|failed" && echo "FAILED" || echo "PASSED"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "FAILED"
+    - result.systemout ShouldContainSubstring "FAILED"
 
 - name: expr - invalid date
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      go run . -x '2024-13-01' --format sql 2>&1 | grep -q -i "error\|failed\|invalid" && echo "ERROR" || echo "OK"
+      go run ./cmd/calcdate -x '2024-13-01' --format sql 2>&1 | grep -q -i "error\|failed\|invalid" && echo "ERROR" || echo "OK"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContain "ERROR"
+    - result.systemout ShouldContainSubstring "ERROR"
 
 - name: expr - iteration exceeds range
   steps:
   - type: exec
     script: |
       cd {{.venom.testsuite.workdir}}/..
-      result=$(go run . -x '2024-01-01 ... 2024-01-02' --each 1w --format sql | wc -l | tr -d ' ')
+      result=$(go run ./cmd/calcdate -x '2024-01-01 ... 2024-01-02' --each 1w --format sql | wc -l | tr -d ' ')
       [ "$result" = "1" ]
     assertions:
     - result.code ShouldEqual 0

--- a/operation_registry.go
+++ b/operation_registry.go
@@ -1,0 +1,364 @@
+package calcdate
+
+// OperationInfo contains metadata about a date operation.
+type OperationInfo struct {
+	Name        string   // Primary name of the operation
+	Category    string   // Category for grouping (e.g., "Arithmetic", "Boundaries - Day")
+	Description string   // Human-readable description
+	Example     string   // Usage example
+	Aliases     []string // Alternative names for this operation
+}
+
+// OperationCategory represents a group of related operations.
+type OperationCategory struct {
+	Name       string          // Category display name
+	Operations []OperationInfo // Operations in this category
+}
+
+// GetOperationRegistry returns a comprehensive list of all available operations
+// organized by category for documentation and help display purposes.
+//
+//nolint:funlen,maintidx // Function is long due to comprehensive operation data, not complexity
+func GetOperationRegistry() []OperationCategory {
+	return []OperationCategory{
+		{
+			Name: "Date Values",
+			Operations: []OperationInfo{
+				{
+					Name:        "today",
+					Category:    "Date Values",
+					Description: "Start of today (00:00:00 in specified timezone)",
+					Example:     `calcdate -x "today"`,
+				},
+				{
+					Name:        "now",
+					Category:    "Date Values",
+					Description: "Current date and time",
+					Example:     `calcdate -x "now"`,
+				},
+				{
+					Name:        "yesterday",
+					Category:    "Date Values",
+					Description: "Start of yesterday (00:00:00)",
+					Example:     `calcdate -x "yesterday"`,
+				},
+				{
+					Name:        "tomorrow",
+					Category:    "Date Values",
+					Description: "Start of tomorrow (00:00:00)",
+					Example:     `calcdate -x "tomorrow"`,
+				},
+				{
+					Name:        "monday",
+					Category:    "Date Values",
+					Description: "Next Monday (00:00:00)",
+					Example:     `calcdate -x "monday"`,
+				},
+				{
+					Name:        "tuesday",
+					Category:    "Date Values",
+					Description: "Next Tuesday (00:00:00)",
+					Example:     `calcdate -x "tuesday"`,
+				},
+				{
+					Name:        "wednesday",
+					Category:    "Date Values",
+					Description: "Next Wednesday (00:00:00)",
+					Example:     `calcdate -x "wednesday"`,
+				},
+				{
+					Name:        "thursday",
+					Category:    "Date Values",
+					Description: "Next Thursday (00:00:00)",
+					Example:     `calcdate -x "thursday"`,
+				},
+				{
+					Name:        "friday",
+					Category:    "Date Values",
+					Description: "Next Friday (00:00:00)",
+					Example:     `calcdate -x "friday"`,
+				},
+				{
+					Name:        "saturday",
+					Category:    "Date Values",
+					Description: "Next Saturday (00:00:00)",
+					Example:     `calcdate -x "saturday"`,
+				},
+				{
+					Name:        "sunday",
+					Category:    "Date Values",
+					Description: "Next Sunday (00:00:00)",
+					Example:     `calcdate -x "sunday"`,
+				},
+			},
+		},
+		{
+			Name: "Arithmetic Operations",
+			Operations: []OperationInfo{
+				{
+					Name:        "+<value><unit>",
+					Category:    "Arithmetic Operations",
+					Description: "Add time duration (e.g., +1d, +2h, +3M)",
+					Example:     `calcdate -x "today +1d +2h"`,
+				},
+				{
+					Name:        "-<value><unit>",
+					Category:    "Arithmetic Operations",
+					Description: "Subtract time duration (e.g., -1d, -2h, -3M)",
+					Example:     `calcdate -x "now -3M -5d"`,
+				},
+			},
+		},
+		{
+			Name: "Time Units",
+			Operations: []OperationInfo{
+				{
+					Name:        "s",
+					Category:    "Time Units",
+					Description: "Seconds",
+					Example:     `calcdate -x "now +30s"`,
+				},
+				{
+					Name:        "m",
+					Category:    "Time Units",
+					Description: "Minutes",
+					Example:     `calcdate -x "now +15m"`,
+				},
+				{
+					Name:        "h",
+					Category:    "Time Units",
+					Description: "Hours",
+					Example:     `calcdate -x "now +2h"`,
+				},
+				{
+					Name:        "d",
+					Category:    "Time Units",
+					Description: "Days",
+					Example:     `calcdate -x "today +7d"`,
+				},
+				{
+					Name:        "w",
+					Category:    "Time Units",
+					Description: "Weeks (7 days)",
+					Example:     `calcdate -x "today +2w"`,
+				},
+				{
+					Name:        "M",
+					Category:    "Time Units",
+					Description: "Months",
+					Example:     `calcdate -x "today +1M"`,
+				},
+				{
+					Name:        "Y",
+					Category:    "Time Units",
+					Description: "Years",
+					Example:     `calcdate -x "today +1Y"`,
+				},
+				{
+					Name:        "q",
+					Category:    "Time Units",
+					Description: "Quarters (3 months)",
+					Example:     `calcdate -x "today +1q"`,
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Day",
+			Operations: []OperationInfo{
+				{
+					Name:        "start",
+					Category:    "Boundaries - Day",
+					Description: "Start of day (00:00:00)",
+					Example:     `calcdate -x "now | start"`,
+					Aliases:     []string{"startofday"},
+				},
+				{
+					Name:        "startofday",
+					Category:    "Boundaries - Day",
+					Description: "Start of day (00:00:00)",
+					Example:     `calcdate -x "now | startofday"`,
+					Aliases:     []string{"start"},
+				},
+				{
+					Name:        "end",
+					Category:    "Boundaries - Day",
+					Description: "End of day (23:59:59.999999999)",
+					Example:     `calcdate -x "today | end"`,
+					Aliases:     []string{"endofday"},
+				},
+				{
+					Name:        "endofday",
+					Category:    "Boundaries - Day",
+					Description: "End of day (23:59:59.999999999)",
+					Example:     `calcdate -x "today | endofday"`,
+					Aliases:     []string{"end"},
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Week",
+			Operations: []OperationInfo{
+				{
+					Name:        "startofweek",
+					Category:    "Boundaries - Week",
+					Description: "Start of week (Monday 00:00:00)",
+					Example:     `calcdate -x "today | startofweek"`,
+				},
+				{
+					Name:        "endofweek",
+					Category:    "Boundaries - Week",
+					Description: "End of week (Sunday 23:59:59.999999999)",
+					Example:     `calcdate -x "today | endofweek"`,
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Month",
+			Operations: []OperationInfo{
+				{
+					Name:        "startofmonth",
+					Category:    "Boundaries - Month",
+					Description: "First day of month (00:00:00)",
+					Example:     `calcdate -x "today | startofmonth"`,
+				},
+				{
+					Name:        "endofmonth",
+					Category:    "Boundaries - Month",
+					Description: "Last day of month (23:59:59.999999999)",
+					Example:     `calcdate -x "today | endofmonth"`,
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Year",
+			Operations: []OperationInfo{
+				{
+					Name:        "startofyear",
+					Category:    "Boundaries - Year",
+					Description: "January 1st (00:00:00)",
+					Example:     `calcdate -x "today | startofyear"`,
+				},
+				{
+					Name:        "endofyear",
+					Category:    "Boundaries - Year",
+					Description: "December 31st (23:59:59.999999999)",
+					Example:     `calcdate -x "today | endofyear"`,
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Quarter",
+			Operations: []OperationInfo{
+				{
+					Name:        "startofquarter",
+					Category:    "Boundaries - Quarter",
+					Description: "First day of current quarter (00:00:00)",
+					Example:     `calcdate -x "today | startofquarter"`,
+				},
+				{
+					Name:        "endofquarter",
+					Category:    "Boundaries - Quarter",
+					Description: "Last day of current quarter (23:59:59.999999999)",
+					Example:     `calcdate -x "today | endofquarter"`,
+				},
+			},
+		},
+		{
+			Name: "Boundaries - Time",
+			Operations: []OperationInfo{
+				{
+					Name:        "startofhour",
+					Category:    "Boundaries - Time",
+					Description: "Start of current hour (:00:00)",
+					Example:     `calcdate -x "now | startofhour"`,
+				},
+				{
+					Name:        "endofhour",
+					Category:    "Boundaries - Time",
+					Description: "End of current hour (:59:59.999999999)",
+					Example:     `calcdate -x "now | endofhour"`,
+				},
+				{
+					Name:        "startofminute",
+					Category:    "Boundaries - Time",
+					Description: "Start of current minute (:00)",
+					Example:     `calcdate -x "now | startofminute"`,
+				},
+				{
+					Name:        "endofminute",
+					Category:    "Boundaries - Time",
+					Description: "End of current minute (:59.999999999)",
+					Example:     `calcdate -x "now | endofminute"`,
+				},
+				{
+					Name:        "startofsecond",
+					Category:    "Boundaries - Time",
+					Description: "Start of current second (.000000000)",
+					Example:     `calcdate -x "now | startofsecond"`,
+				},
+				{
+					Name:        "endofsecond",
+					Category:    "Boundaries - Time",
+					Description: "End of current second (.999999999)",
+					Example:     `calcdate -x "now | endofsecond"`,
+				},
+			},
+		},
+		{
+			Name: "Value Setters",
+			Operations: []OperationInfo{
+				{
+					Name:        "day <value>",
+					Category:    "Value Setters",
+					Description: "Set specific day of month (1-31)",
+					Example:     `calcdate -x "today | day 15"`,
+				},
+				{
+					Name:        "time <HH:MM:SS>",
+					Category:    "Value Setters",
+					Description: "Set specific time",
+					Example:     `calcdate -x "today | time 14:30:00"`,
+				},
+			},
+		},
+		{
+			Name: "Transform Operations",
+			Operations: []OperationInfo{
+				{
+					Name:        "round <unit>",
+					Category:    "Transform Operations",
+					Description: "Round to nearest unit (day, hour, minute)",
+					Example:     `calcdate -x "now | round hour"`,
+				},
+				{
+					Name:        "trunc <unit>",
+					Category:    "Transform Operations",
+					Description: "Truncate to unit boundary (day, hour, minute)",
+					Example:     `calcdate -x "now | trunc hour"`,
+				},
+			},
+		},
+		{
+			Name: "Range Operations",
+			Operations: []OperationInfo{
+				{
+					Name:        "...",
+					Category:    "Range Operations",
+					Description: "Create date range (requires -each flag for iteration)",
+					Example:     `calcdate -x "today...+7d" -each 1d`,
+				},
+			},
+		},
+		{
+			Name: "Pipeline Operations",
+			Operations: []OperationInfo{
+				{
+					Name:        "|",
+					Category:    "Pipeline Operations",
+					Description: "Chain operations together",
+					Example:     `calcdate -x "today | +1M | endofmonth"`,
+				},
+			},
+		},
+	}
+}

--- a/operation_registry_test.go
+++ b/operation_registry_test.go
@@ -1,0 +1,136 @@
+package calcdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOperationRegistry(t *testing.T) {
+	registry := GetOperationRegistry()
+
+	// Verify we have categories
+	assert.NotEmpty(t, registry, "Registry should not be empty")
+	assert.Greater(t, len(registry), 5, "Should have multiple categories")
+
+	// Verify each category has operations
+	for _, cat := range registry {
+		assert.NotEmpty(t, cat.Name, "Category should have a name")
+		assert.NotEmpty(t, cat.Operations, "Category should have operations")
+
+		// Verify each operation has required fields
+		for _, op := range cat.Operations {
+			assert.NotEmpty(t, op.Name, "Operation should have a name")
+			assert.NotEmpty(t, op.Category, "Operation should have a category")
+			assert.NotEmpty(t, op.Description, "Operation should have a description")
+			assert.NotEmpty(t, op.Example, "Operation should have an example")
+		}
+	}
+}
+
+func TestOperationRegistryCategories(t *testing.T) {
+	registry := GetOperationRegistry()
+
+	expectedCategories := []string{
+		"Date Values",
+		"Arithmetic Operations",
+		"Time Units",
+		"Boundaries - Day",
+		"Boundaries - Week",
+		"Boundaries - Month",
+		"Boundaries - Year",
+		"Boundaries - Quarter",
+		"Boundaries - Time",
+		"Value Setters",
+		"Transform Operations",
+		"Range Operations",
+		"Pipeline Operations",
+	}
+
+	// Build map of actual categories
+	actualCategories := make(map[string]bool)
+	for _, cat := range registry {
+		actualCategories[cat.Name] = true
+	}
+
+	// Verify all expected categories exist
+	for _, expected := range expectedCategories {
+		assert.True(t, actualCategories[expected], "Expected category %s not found", expected)
+	}
+}
+
+func TestOperationRegistryKeyOperations(t *testing.T) {
+	registry := GetOperationRegistry()
+
+	// Flatten all operations into a map for easier lookup
+	operations := make(map[string]OperationInfo)
+	for _, cat := range registry {
+		for _, op := range cat.Operations {
+			operations[op.Name] = op
+		}
+	}
+
+	// Verify key operations exist
+	keyOps := []string{
+		"today",
+		"now",
+		"yesterday",
+		"tomorrow",
+		"start",
+		"startofday",
+		"end",
+		"endofday",
+		"startofweek",
+		"endofweek",
+		"startofmonth",
+		"endofmonth",
+		"startofyear",
+		"endofyear",
+		"startofquarter",
+		"endofquarter",
+	}
+
+	for _, opName := range keyOps {
+		op, exists := operations[opName]
+		assert.True(t, exists, "Key operation %s should exist", opName)
+		assert.NotEmpty(t, op.Description, "Operation %s should have description", opName)
+		assert.NotEmpty(t, op.Example, "Operation %s should have example", opName)
+	}
+}
+
+func TestOperationRegistryAliases(t *testing.T) {
+	registry := GetOperationRegistry()
+
+	// Find operations with aliases
+	var opsWithAliases []OperationInfo
+	for _, cat := range registry {
+		for _, op := range cat.Operations {
+			if len(op.Aliases) > 0 {
+				opsWithAliases = append(opsWithAliases, op)
+			}
+		}
+	}
+
+	// Verify "start" and "startofday" are aliases
+	found := false
+	for _, op := range opsWithAliases {
+		if op.Name == "start" || op.Name == "startofday" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should have start/startofday aliases documented")
+}
+
+func TestOperationRegistryExamplesFormat(t *testing.T) {
+	registry := GetOperationRegistry()
+
+	for _, cat := range registry {
+		for _, op := range cat.Operations {
+			// All examples should contain "calcdate"
+			assert.Contains(t, op.Example, "calcdate", "Example for %s should contain 'calcdate'", op.Name)
+			// All examples should contain "-x" flag
+			assert.Contains(t, op.Example, "-x", "Example for %s should contain '-x' flag", op.Name)
+		}
+	}
+}


### PR DESCRIPTION
Implement comprehensive operation listing with:
- --list-ops flag to show all date operations organized by category
- Operation registry with descriptions, examples, and aliases
- Custom usage function with quick command examples
- Enhanced help text for better discoverability

Fix e2e tests:
- Update test paths to use ./cmd/calcdate (new project structure)
- Replace ShouldContain with ShouldContainSubstring for venom

All 112 e2e tests pass.