### PR TITLE
feat(parser): add error suggestions for typos in expressions

### DIFF
--- a/expr_parser.go
+++ b/expr_parser.go
@@ -9,6 +9,7 @@ import (
 type ExprParser struct {
 	tokens []Token
 	pos    int
+	input  string
 }
 
 // NewExprParser creates a new expression parser.
@@ -25,9 +26,10 @@ func (p *ExprParser) Parse(input string) (ExprNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tokenization failed: %w", err)
 	}
-	
+
 	p.tokens = tokens
 	p.pos = 0
+	p.input = input
 	
 	return p.parseExpression()
 }
@@ -221,7 +223,13 @@ func (p *ExprParser) parseOperation() (ExprNode, error) {
 		return p.parseUnitOperation(token)
 	case TokenKeyword:
 		return p.parseKeywordOperation(token)
-	case TokenEOF, TokenDate, TokenPipe, TokenRange, TokenVariable,
+	case TokenDate:
+		// Check if the value is a misspelled operation
+		if suggestions := findSuggestions(token.Value, validOperationNames()); len(suggestions) > 0 {
+			return nil, newUnknownOperationError(token.Value, token.Pos, p.input)
+		}
+		return nil, fmt.Errorf("%w: got %v", ErrExpectedOperationAfterPipe, token)
+	case TokenEOF, TokenPipe, TokenRange, TokenVariable,
 		TokenNumber, TokenTime, TokenComma, TokenLParen, TokenRParen:
 		return nil, fmt.Errorf("%w: got %v", ErrExpectedOperationAfterPipe, token)
 	default:
@@ -276,7 +284,7 @@ func (p *ExprParser) parseKeywordOperation(token Token) (ExprNode, error) {
 		return &OperationNode{Op: keyword, Value: ""}, nil
 	}
 	
-	return nil, fmt.Errorf("%w: %s", ErrUnknownOperation, keyword)
+	return nil, newUnknownOperationError(keyword, token.Pos, p.input)
 }
 
 func (p *ExprParser) isArgumentOperation(keyword string) bool {

--- a/expr_parser_test.go
+++ b/expr_parser_test.go
@@ -178,6 +178,35 @@ func TestTransformParsing(t *testing.T) {
 	assert.NotNil(t, transform.EndExpr)
 }
 
+func TestExprParserErrorSuggestions(t *testing.T) {
+	tests := []struct {
+		input           string
+		description     string
+		expectedContain string
+	}{
+		{
+			input:           "today | startofmoonth",
+			description:     "typo in startofmonth",
+			expectedContain: "startofmonth",
+		},
+		{
+			input:           "today | endofwek",
+			description:     "typo in endofweek",
+			expectedContain: "endofweek",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			parser := NewExprParser(tc.input)
+			_, err := parser.Parse(tc.input)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrUnknownOperation)
+			assert.Contains(t, err.Error(), tc.expectedContain)
+		})
+	}
+}
+
 func TestOperations(t *testing.T) {
 	baseTime := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	

--- a/operations.go
+++ b/operations.go
@@ -42,7 +42,7 @@ func ParseDateValue(value string, ctx *EvalContext) (time.Time, error) {
 		return t, nil
 	}
 	
-	return time.Time{}, fmt.Errorf("%w: %s", ErrInvalidDateValue, value)
+	return time.Time{}, newInvalidDateValueError(value)
 }
 
 func parseBuiltinKeywords(value string, now time.Time, loc *time.Location) (time.Time, bool) {
@@ -163,7 +163,7 @@ func applyRelativeDelta(base time.Time, num int, unit string) (time.Time, error)
 	case "q":
 		return base.AddDate(0, num*MonthsInQuarter, 0), nil
 	default:
-		return time.Time{}, fmt.Errorf("%w: %s", ErrUnknownUnit, unit)
+		return time.Time{}, newUnknownUnitError(unit)
 	}
 }
 
@@ -234,7 +234,7 @@ func ApplyOperation(date time.Time, op, value string, loc *time.Location) (time.
 		return result.t, result.err
 	}
 	
-	return time.Time{}, fmt.Errorf("%w: %s", ErrUnknownOperation, op)
+	return time.Time{}, newUnknownOperationError(op, -1, "")
 }
 
 type operationResult struct {

--- a/suggestions.go
+++ b/suggestions.go
@@ -1,0 +1,222 @@
+package calcdate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Suggestion engine constants.
+const (
+	maxSuggestions          = 3
+	shortInputLen          = 3
+	mediumInputLen         = 6
+	shortInputMaxDistance   = 1
+	mediumInputMaxDistance  = 2
+	longInputMaxDistance    = 3
+)
+
+// ExpressionError is a custom error type that provides suggestions and context
+// for invalid expressions.
+type ExpressionError struct {
+	Wrapped      error
+	Message      string
+	Suggestions  []string
+	ValidOptions []string
+	Position     int
+	Expression   string
+}
+
+func (e *ExpressionError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.Message)
+
+	if len(e.Suggestions) > 0 {
+		b.WriteString(". Did you mean: ")
+		b.WriteString(strings.Join(e.Suggestions, ", "))
+		b.WriteString("?")
+	}
+
+	if len(e.ValidOptions) > 0 {
+		b.WriteString(". Valid options: ")
+		b.WriteString(strings.Join(e.ValidOptions, ", "))
+	}
+
+	if e.Position >= 0 && e.Expression != "" {
+		b.WriteString("\n")
+		b.WriteString(formatPositionHighlight(e.Expression, e.Position))
+	}
+
+	return b.String()
+}
+
+// Unwrap returns the wrapped sentinel error for errors.Is() compatibility.
+func (e *ExpressionError) Unwrap() error {
+	return e.Wrapped
+}
+
+// levenshteinDistance computes the Levenshtein distance between two strings.
+func levenshteinDistance(a, b string) int {
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				curr[j-1]+1,
+				prev[j]+1,
+				prev[j-1]+cost,
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[len(b)]
+}
+
+type suggestion struct {
+	name     string
+	distance int
+}
+
+// findSuggestions returns up to maxSuggestions closest matches within the
+// threshold derived from input length.
+func findSuggestions(input string, candidates []string) []string {
+	maxDistance := autoThreshold(len(input))
+
+	var matches []suggestion
+	lower := strings.ToLower(input)
+
+	for _, c := range candidates {
+		d := levenshteinDistance(lower, strings.ToLower(c))
+		if d > 0 && d <= maxDistance {
+			matches = append(matches, suggestion{c, d})
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].distance < matches[j].distance
+	})
+
+	result := make([]string, 0, maxSuggestions)
+	for i := 0; i < len(matches) && i < maxSuggestions; i++ {
+		result = append(result, matches[i].name)
+	}
+
+	return result
+}
+
+func autoThreshold(inputLen int) int {
+	switch {
+	case inputLen <= shortInputLen:
+		return shortInputMaxDistance
+	case inputLen <= mediumInputLen:
+		return mediumInputMaxDistance
+	default:
+		return longInputMaxDistance
+	}
+}
+
+// validOperationNames returns all recognized operation keywords.
+func validOperationNames() []string {
+	return []string{
+		"start", "startofday", "end", "endofday",
+		"startofweek", "endofweek",
+		"startofmonth", "endofmonth",
+		"startofyear", "endofyear",
+		"startofquarter", "endofquarter",
+		"startofhour", "endofhour",
+		"startofminute", "endofminute",
+		"startofsecond", "endofsecond",
+		"day", "time", "round", "trunc",
+	}
+}
+
+// validDateKeywords returns all recognized date keywords.
+func validDateKeywords() []string {
+	return []string{
+		"today", "now", "yesterday", "tomorrow",
+		"monday", "tuesday", "wednesday", "thursday",
+		"friday", "saturday", "sunday",
+	}
+}
+
+// validUnits returns all recognized time units with descriptions.
+func validUnits() []string {
+	return []string{
+		"s (seconds)", "m (minutes)", "h (hours)", "d (days)",
+		"w (weeks)", "M (months)", "Y (years)", "q (quarters)",
+	}
+}
+
+// validUnitLetters returns just the unit letters for suggestion matching.
+func validUnitLetters() []string {
+	return []string{"s", "m", "h", "d", "w", "M", "Y", "q"}
+}
+
+func newUnknownOperationError(op string, pos int, expr string) *ExpressionError {
+	suggestions := findSuggestions(op, validOperationNames())
+
+	return &ExpressionError{
+		Wrapped:     ErrUnknownOperation,
+		Message:     fmt.Sprintf("%s: %s", ErrUnknownOperation.Error(), op),
+		Suggestions: suggestions,
+		Position:    pos,
+		Expression:  expr,
+	}
+}
+
+func newUnknownUnitError(unit string) *ExpressionError {
+	suggestions := findSuggestions(unit, validUnitLetters())
+
+	return &ExpressionError{
+		Wrapped:      ErrUnknownUnit,
+		Message:      fmt.Sprintf("%s: %s", ErrUnknownUnit.Error(), unit),
+		Suggestions:  suggestions,
+		ValidOptions: validUnits(),
+		Position:     -1,
+	}
+}
+
+func newInvalidDateValueError(value string) *ExpressionError {
+	suggestions := findSuggestions(value, validDateKeywords())
+
+	return &ExpressionError{
+		Wrapped:     ErrInvalidDateValue,
+		Message:     fmt.Sprintf("%s: %s", ErrInvalidDateValue.Error(), value),
+		Suggestions: suggestions,
+		Position:    -1,
+	}
+}
+
+// formatPositionHighlight generates a caret marker under the problematic position.
+func formatPositionHighlight(expr string, pos int) string {
+	if pos < 0 || pos > len(expr) {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("  ")
+	b.WriteString(expr)
+	b.WriteString("\n  ")
+	b.WriteString(strings.Repeat(" ", pos))
+	b.WriteString("^")
+
+	return b.String()
+}

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -1,0 +1,174 @@
+package calcdate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b     string
+		expected int
+	}{
+		{"", "", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"abc", "abc", 0},
+		{"kitten", "sitting", 3},
+		{"startofmonth", "startofmoonth", 1},
+		{"endofweek", "endofwek", 1},
+		{"today", "tooday", 1},
+		{"tomorrow", "tomorow", 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.a+"_"+tc.b, func(t *testing.T) {
+			assert.Equal(t, tc.expected, levenshteinDistance(tc.a, tc.b))
+		})
+	}
+}
+
+func TestFindSuggestions(t *testing.T) {
+	t.Run("finds close matches", func(t *testing.T) {
+		candidates := []string{"startofmonth", "endofmonth", "startofweek"}
+		result := findSuggestions("startofmoonth", candidates)
+		require.Len(t, result, 1)
+		assert.Equal(t, "startofmonth", result[0])
+	})
+
+	t.Run("respects threshold", func(t *testing.T) {
+		candidates := []string{"startofmonth", "endofmonth"}
+		result := findSuggestions("xyz", candidates)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns at most 3 suggestions", func(t *testing.T) {
+		candidates := validOperationNames()
+		result := findSuggestions("startof", candidates)
+		assert.LessOrEqual(t, len(result), maxSuggestions)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		candidates := []string{"startofmonth", "endofmonth"}
+		result := findSuggestions("completelyunrelated", candidates)
+		assert.Empty(t, result)
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		candidates := []string{"startOfMonth", "endOfMonth"}
+		result := findSuggestions("StartOfMoonth", candidates)
+		require.Len(t, result, 1)
+		assert.Equal(t, "startOfMonth", result[0])
+	})
+}
+
+func TestExpressionErrorUnwrap(t *testing.T) {
+	err := &ExpressionError{
+		Wrapped: ErrUnknownOperation,
+		Message: "unknown operation: foo",
+	}
+
+	assert.True(t, errors.Is(err, ErrUnknownOperation))
+	assert.False(t, errors.Is(err, ErrUnknownUnit))
+}
+
+func TestExpressionErrorMessage(t *testing.T) {
+	t.Run("with suggestions", func(t *testing.T) {
+		err := &ExpressionError{
+			Wrapped:     ErrUnknownOperation,
+			Message:     "unknown operation: startofmoonth",
+			Suggestions: []string{"startofmonth"},
+			Position:    -1,
+		}
+
+		msg := err.Error()
+		assert.Contains(t, msg, "Did you mean: startofmonth?")
+	})
+
+	t.Run("with valid options", func(t *testing.T) {
+		err := &ExpressionError{
+			Wrapped:      ErrUnknownUnit,
+			Message:      "unknown unit: x",
+			ValidOptions: []string{"s (seconds)", "m (minutes)"},
+			Position:     -1,
+		}
+
+		msg := err.Error()
+		assert.Contains(t, msg, "Valid options: s (seconds), m (minutes)")
+	})
+
+	t.Run("with position highlight", func(t *testing.T) {
+		err := &ExpressionError{
+			Wrapped:    ErrUnknownOperation,
+			Message:    "unknown operation: startofmoonth",
+			Position:   8,
+			Expression: "today | startofmoonth",
+		}
+
+		msg := err.Error()
+		assert.Contains(t, msg, "today | startofmoonth")
+		assert.Contains(t, msg, "^")
+	})
+
+	t.Run("no extras", func(t *testing.T) {
+		err := &ExpressionError{
+			Wrapped:  ErrUnknownOperation,
+			Message:  "unknown operation: foo",
+			Position: -1,
+		}
+
+		assert.Equal(t, "unknown operation: foo", err.Error())
+	})
+}
+
+func TestFormatPositionHighlight(t *testing.T) {
+	t.Run("highlights correct position", func(t *testing.T) {
+		result := formatPositionHighlight("today | startofmoonth", 8)
+		assert.Contains(t, result, "today | startofmoonth")
+		assert.Contains(t, result, "        ^")
+	})
+
+	t.Run("position at start", func(t *testing.T) {
+		result := formatPositionHighlight("foo", 0)
+		assert.Contains(t, result, "foo")
+		assert.Contains(t, result, "^")
+	})
+
+	t.Run("negative position returns empty", func(t *testing.T) {
+		result := formatPositionHighlight("foo", -1)
+		assert.Empty(t, result)
+	})
+
+	t.Run("position beyond string returns empty", func(t *testing.T) {
+		result := formatPositionHighlight("foo", 10)
+		assert.Empty(t, result)
+	})
+}
+
+func TestNewUnknownOperationError(t *testing.T) {
+	err := newUnknownOperationError("startofmoonth", -1, "")
+
+	assert.True(t, errors.Is(err, ErrUnknownOperation))
+	assert.Contains(t, err.Error(), "startofmoonth")
+	assert.Contains(t, err.Error(), "Did you mean: startofmonth?")
+}
+
+func TestNewUnknownUnitError(t *testing.T) {
+	err := newUnknownUnitError("x")
+
+	assert.True(t, errors.Is(err, ErrUnknownUnit))
+	assert.Contains(t, err.Error(), "unknown unit: x")
+	assert.Contains(t, err.Error(), "Valid options:")
+	assert.Contains(t, err.Error(), "d (days)")
+}
+
+func TestNewInvalidDateValueError(t *testing.T) {
+	err := newInvalidDateValueError("tomorow")
+
+	assert.True(t, errors.Is(err, ErrInvalidDateValue))
+	assert.Contains(t, err.Error(), "tomorow")
+	assert.Contains(t, err.Error(), "Did you mean: tomorrow?")
+}


### PR DESCRIPTION
Implement Levenshtein distance-based suggestion engine that provides
"Did you mean?" hints when users mistype operations, units, or date
keywords. Includes position highlighting in error output.

Closes #46