### PR TITLE
fix(homebrew): chmod +x installed binary to prevent EACCES on exec

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,7 @@ brews:
     url_template: 'https://github.com/sgaunet/calcdate/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
     install: |
       bin.install "{{ .ArtifactName }}" => "calcdate"
+      chmod 0555, bin/"calcdate"
       output = Utils.safe_popen_read(bin/"calcdate", "completion", "bash")
       (bash_completion/"calcdate").write output
       output = Utils.safe_popen_read(bin/"calcdate", "completion", "zsh")
@@ -60,4 +61,4 @@ brews:
       output = Utils.safe_popen_read(bin/"calcdate", "completion", "fish")
       (fish_completion/"calcdate.fish").write output
     test: |
-      system "#{bin}/calcdate", "--version"
+      system "#{bin}/calcdate", "-v"


### PR DESCRIPTION
Homebrew 5.x's bin.install no longer auto-chmods +x; it preserves
source permissions. Release artifacts downloaded by curl have mode
644 (umask 022), so the install-time call to safe_popen_read fails
with EACCES when trying to run `calcdate completion bash`, which
brew misreports as "exited with 1".

Add `chmod 0555, bin/"calcdate"` between bin.install and the
completion-generation calls. Also revert the formula's test command
from `--version` back to `-v` for consistency.

Closes #63