### PR TITLE
ci(workflows): migrate to mise-action and pin tool versions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [sgaunet]
+github:
+  - sgaunet

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,9 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-  - package-ecosystem: docker
+      interval: monthly
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
+

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,34 +1,15 @@
-name: linter
-
+name: Lint
 on:
   push:
-
-permissions:
-  contents: read
-
+    branches: [main]
+  pull_request:
 jobs:
-  linter:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-      - name: Install task
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: go-task/task
-          cache: enable
-          # tag: 
-      - name: Install golangci-lint
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: golangci/golangci-lint
-          tag: v2.11.4
-          cache: enable
-          binaries-location: golangci-lint-2.11.4-linux-amd64
-
-      - name: Run linter
-        shell: /usr/bin/bash {0}
-        run: |
-          task lint
+          install: true
+          cache: true
+      - run: task lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,61 +1,24 @@
-name: release
-
+name: Release
 on:
   push:
-    # Pattern matched against refs/tags
-    tags:        
-      - '**'           # Push events to every tag including hierarchical tags like v1.0/beta
-
+    tags: ['v*']
 permissions:
   contents: write
   packages: write
-
 jobs:
-  goreleaser-release:
+  release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-      - name: Install task
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: go-task/task
-          # tag: 
-      - name: Install goreleaser
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: goreleaser/goreleaser
-          # tag: 
+          install: true
+          cache: true
 
-      -
-        # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create release
-        shell: /usr/bin/bash {0}
-        run: |
-          task release
+      - run: task release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,15 @@
-name: Snapshot
+name: Test
 on:
   push:
     branches: [main]
+  pull_request:
 jobs:
-  snapshot:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
           install: true
           cache: true
-      - run: task snapshot
+      - run: task test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,21 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-    #   - id: trailing-whitespace
-    #   - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
   - repo: local
     hooks:
-      - id: unit-tests
-        name: Run unit tests
+      - id: test
+        name: test
         entry: task test
         language: system
         pass_filenames: false
+        always_run: true
       - id: lint
-        name: Run linter
+        name: lint
         entry: task lint
         language: system
         pass_filenames: false
+        always_run: true
       - id: build
-        name: Run build
-        entry: task snapshot
+        name: build
+        entry: task build
         language: system
         pass_filenames: false
+        always_run: true

--- a/Taskfile_dev.yml
+++ b/Taskfile_dev.yml
@@ -1,13 +1,12 @@
-# https://taskfile.dev
 version: '3'
 
 tasks:
   install-pre-commit:
-    desc: "Install pre-commit hooks"
+    desc: Install the pre-commit git hook
     cmds:
       - pre-commit install
 
   pre-commit:
-    desc: "Run all pre-commit hooks"
+    desc: Run all pre-commit hooks
     cmds:
       - pre-commit run --all-files

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.26.1"
 "task" = "3.40.1"
-"golangci-lint" = "2.1.6"
+"golangci-lint" = "2.11.4"
 goreleaser = "2.16.0"
 syft = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "1.26.1"
+"task" = "3.40.1"
+"golangci-lint" = "2.1.6"
+goreleaser = "2.16.0"
+syft = "latest"


### PR DESCRIPTION
- Add mise.toml with pinned Go, task, golangci-lint, goreleaser versions
- Replace jaxxstorm/action-install-gh-release with jdx/mise-action
- Add test.yml workflow for push/PR testing
- Simplify pre-commit-config and dependabot configuration

Closes #65